### PR TITLE
Added synchronous GRPC call option for row commit

### DIFF
--- a/gcloud_bigtable/row.py
+++ b/gcloud_bigtable/row.py
@@ -420,8 +420,10 @@ class Row(object):
         )
         timeout_seconds = timeout_seconds or self.timeout_seconds
         # We expect a `._generated.empty_pb2.Empty`.
-        response = self.client.data_stub.MutateRow.async(request_pb, timeout_seconds).result() if async \
-            else self.client.data_stub.MutateRow(request_pb, timeout_seconds)
+        if async:
+            self.client.data_stub.MutateRow.async(request_pb, timeout_seconds).result()
+        else:
+            self.client.data_stub.MutateRow(request_pb, timeout_seconds)
 
     def _commit_check_and_mutate(self, timeout_seconds=None, async=True):
         """Makes a ``CheckAndMutateRow`` API request.
@@ -464,9 +466,11 @@ class Row(object):
         )
         timeout_seconds = timeout_seconds or self.timeout_seconds
         # We expect a `.messages_pb2.CheckAndMutateRowResponse`
-        check_and_mutate_row_response = self.client.data_stub.CheckAndMutateRow.async(
-            request_pb, timeout_seconds).result() if async \
-            else self.client.data_stub.CheckAndMutateRow(request_pb, timeout_seconds)
+        if async:
+            response = self.client.data_stub.CheckAndMutateRow.async(request_pb, timeout_seconds)
+            check_and_mutate_row_response = response.result()
+        else:
+            check_and_mutate_row_response = self.client.data_stub.CheckAndMutateRow(request_pb, timeout_seconds)
 
         return check_and_mutate_row_response.predicate_matched
 
@@ -580,8 +584,11 @@ class Row(object):
         timeout_seconds = timeout_seconds or self.timeout_seconds
 
         # We expect a `.data_pb2.Row`
-        row_response = self.client.data_stub.ReadModifyWriteRow.async(request_pb, timeout_seconds).result() if async \
-            else self.client.data_stub.ReadModifyWriteRow(request_pb, timeout_seconds)
+        if async:
+            response = self.client.data_stub.ReadModifyWriteRow.async(request_pb, timeout_seconds)
+            row_response = response.result()
+        else:
+            row_response = self.client.data_stub.ReadModifyWriteRow(request_pb, timeout_seconds)
 
         # Reset modifications after commit-ing request.
         self.clear_modification_rules()

--- a/gcloud_bigtable/row.py
+++ b/gcloud_bigtable/row.py
@@ -435,8 +435,8 @@ class Row(object):
         :param timeout_seconds: Number of seconds for request time-out.
                                 If not passed, defaults to value set on row.
 
-        :type async: bytes
-        :param async: Boolean indicating if the GRPC call should be done asynchronous
+        :type async: bool
+        :param async: Boolean indicating if the GRPC call should be done asynchronously
 
         :rtype: bool
         :returns: Flag indicating if the filter was matched (which also
@@ -503,8 +503,8 @@ class Row(object):
         :param timeout_seconds: Number of seconds for request time-out.
                                 If not passed, defaults to value set on row.
 
-        :type async: bytes
-        :param async: Boolean indicating if the GRPC call should be done asynchronous
+        :type async: bool
+        :param async: Boolean indicating if the GRPC call should be done asynchronously
 
         :rtype: :class:`bool` or :data:`NoneType <types.NoneType>`
         :returns: :data:`None` if there is no filter, otherwise a flag
@@ -545,8 +545,8 @@ class Row(object):
         :param timeout_seconds: Number of seconds for request time-out.
                                 If not passed, defaults to value set on row.
 
-        :type async: bytes
-        :param async: Boolean indicating if the GRPC call should be done asynchronous
+        :type async: bool
+        :param async: Boolean indicating if the GRPC call should be done asynchronously
 
         :rtype: dict
         :returns: The new contents of all modified cells. Returned as a


### PR DESCRIPTION
This pull request adds an async parameter to the commit method that allows to choose between synchronous and asynchronous GRPC calls.

When executing a couple of hundred write commits per second, the commit method that performs an async GRPC call sometimes never returns. The problem doesn't occur when using the synchronous GRPC call. 
We haven't identified the root cause yet, but it might be an issue in the GRPC library itself, since we ran into the same problem with a custom Java Bigtable client we wrote. 